### PR TITLE
Altered the DSL so that Trait Collections are not bound to models

### DIFF
--- a/lib/set_builder.rb
+++ b/lib/set_builder.rb
@@ -8,31 +8,4 @@ require 'set_builder/engine'
 
 
 module SetBuilder
-    
-  def self.extended(base)
-    base.instance_variable_set("@traits", SetBuilder::Traits.new)
-    base.send(:include, SetBuilder::Modifiers)
-  end
-  
-  
-  attr_reader :traits
-  
-  def modifiers
-    traits.modifiers
-  end
-  
-  def that_belong_to(set)
-    SetBuilder::Set.new(self, to_scope, set)
-  end
-  
-  def to_scope
-    scoped
-  end
-
-protected
-
-  def trait(trait_expression, &block)
-    traits << Trait.new(trait_expression, &block)
-  end
-  
 end

--- a/lib/set_builder/set.rb
+++ b/lib/set_builder/set.rb
@@ -1,17 +1,17 @@
 module SetBuilder
   class Set
-    
-    
-    
-    def initialize(model, scope, raw_data)
-      @model = model
+
+
+
+    def initialize(traits, scope, raw_data)
+      @traits = traits
       @scope = scope
       @set = raw_data
     end
-    
-    
-    
-    attr_reader :model, :scope
+
+
+
+    attr_reader :traits, :scope
 
 
 
@@ -59,8 +59,8 @@ module SetBuilder
       set.inject([]) do |constraints, line|
         negate, trait_name, args = false, line.first.to_s, line[1..-1]
         trait_name, negate = trait_name[1..-1], true if (trait_name[0..0] == "!")
-        trait = model.traits[trait_name]
-        raise("\"#{trait_name}\" is not a trait for #{model}") unless trait
+        trait = traits[trait_name]
+        raise("\"#{trait_name}\" is not a trait in `traits`") unless trait
         constraints << trait.apply(*args).negate(negate)
       end
     end

--- a/lib/set_builder/set.rb
+++ b/lib/set_builder/set.rb
@@ -12,49 +12,49 @@ module SetBuilder
     
     
     attr_reader :model, :scope
-    
-    
-    
+
+
+
     def constraints
       @constraints ||= get_constraints
     end
-    
-    
-    
+
+
+
     #
     # Returns true if all of the constraints in this set are valid
     #
     def valid?
       constraints.all?(&:valid?)
     end
-    
-    
-    
+
+
+
     #
     # Describes this set in natural language
     #
     def to_s
       constraints.to_sentence
     end
-    
-    
-    
+
+
+
     #
     # Returns an instance of ActiveRecord::NamedScope::Scope
     # which can fetch the objects which belong to this set
-    #    
+    #
     def perform
       constraints.inject(scope) { |scope, constraint| constraint.perform(scope) }
     end
-    
-    
-    
+
+
+
   private
-    
-    
-    
+
+
+
     attr_reader :set
-    
+
     def get_constraints
       set.inject([]) do |constraints, line|
         negate, trait_name, args = false, line.first.to_s, line[1..-1]
@@ -64,8 +64,8 @@ module SetBuilder
         constraints << trait.apply(*args).negate(negate)
       end
     end
-    
-    
-    
+
+
+
   end
 end

--- a/lib/set_builder/trait_builder.rb
+++ b/lib/set_builder/trait_builder.rb
@@ -1,0 +1,14 @@
+module SetBuilder
+  class TraitBuilder
+    attr_reader :traits
+
+    def initialize(traits)
+      @traits = traits
+    end
+
+    def trait(trait_expression, &block)
+      traits << Trait.new(trait_expression, &block)
+    end
+
+  end
+end

--- a/lib/set_builder/traits.rb
+++ b/lib/set_builder/traits.rb
@@ -4,9 +4,9 @@ require 'set_builder/modifier_collection'
 
 module SetBuilder
   class Traits < Array
-    
-    
-    
+
+
+
     def [](index)
       case index
       when Symbol, String
@@ -16,15 +16,15 @@ module SetBuilder
         super
       end
     end
-    
-    
-    
+
+
+
     def to_json
       "[#{collect(&:to_json).join(",")}]"
     end
-    
-    
-    
+
+
+
     def modifiers
       # !nb: not sure why inject was failing but it was modifying trait.modifiers!
       @modifiers = ModifierCollection.new
@@ -35,8 +35,8 @@ module SetBuilder
       end
       @modifiers
     end
-    
-    
-    
+
+
+
   end
 end

--- a/lib/set_builder/traits.rb
+++ b/lib/set_builder/traits.rb
@@ -1,9 +1,16 @@
 require 'set_builder/trait'
+require 'set_builder/trait_builder'
 require 'set_builder/modifier_collection'
 
 
 module SetBuilder
   class Traits < Array
+
+
+
+    def initialize(&block)
+      TraitBuilder.new(self).instance_eval(&block) if block_given?
+    end
 
 
 

--- a/lib/set_builder/traits.rb
+++ b/lib/set_builder/traits.rb
@@ -1,14 +1,16 @@
 require 'set_builder/trait'
 require 'set_builder/trait_builder'
 require 'set_builder/modifier_collection'
+require 'delegate'
 
 
 module SetBuilder
-  class Traits < Array
+  class Traits < SimpleDelegator
 
 
 
-    def initialize(&block)
+    def initialize(array=[], &block)
+      super array
       TraitBuilder.new(self).instance_eval(&block) if block_given?
     end
 
@@ -28,6 +30,18 @@ module SetBuilder
 
     def to_json
       "[#{collect(&:to_json).join(",")}]"
+    end
+
+
+
+    def +(other_traits)
+      return super unless other_traits.is_a?(self.class)
+      self.class.new(self.__getobj__ + other_traits.__getobj__)
+    end
+
+    def concat(other_traits)
+      return super unless other_traits.is_a?(self.class)
+      self.class.new(self.__getobj__.concat other_traits.__getobj__)
     end
 
 

--- a/lib/set_builder/traits.rb
+++ b/lib/set_builder/traits.rb
@@ -11,7 +11,14 @@ module SetBuilder
 
     def initialize(array=[], &block)
       super array
-      TraitBuilder.new(self).instance_eval(&block) if block_given?
+
+      if block_given?
+        if block.arity.zero?
+          TraitBuilder.new(self).instance_eval(&block)
+        else
+          yield TraitBuilder.new(self)
+        end
+      end
     end
 
 

--- a/set_builder.gemspec
+++ b/set_builder.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "jspec"
   spec.add_development_dependency "pry"
+  spec.add_development_dependency "minitest-reporters"
 end

--- a/test/modifier_test.rb
+++ b/test/modifier_test.rb
@@ -71,7 +71,7 @@ class ModifierTest < ActiveSupport::TestCase
         "is_not"              => ["string"]
       }
     }
-    assert_equal expected_results, Friend.modifiers.to_hash
+    assert_equal expected_results, $friend_traits.modifiers.to_hash
   end
 
 

--- a/test/modifier_test.rb
+++ b/test/modifier_test.rb
@@ -7,7 +7,7 @@ class ModifierTest < ActiveSupport::TestCase
   test "get type with string" do
     assert_equal StringPreposition, SetBuilder::Modifier["StringPreposition"]
   end
-  
+
   test "get type with symbol" do
     assert_equal StringPreposition, SetBuilder::Modifier[:string]
   end
@@ -21,13 +21,13 @@ class ModifierTest < ActiveSupport::TestCase
       SetBuilder::Modifier.for(:hash)
     end
   end
-  
+
   test "registering an invalid modifier" do
     assert_raises ArgumentError do
       SetBuilder::Modifier.register(:hash, InvalidHashModifier)
     end
   end
-  
+
   test "converting modifier to json" do
     expected_results = {
       "contains"            => ["string"],
@@ -82,9 +82,9 @@ class InvalidHashModifier
 end
 
 class HashModifier < SetBuilder::Modifier::Verb
-  
+
   def self.operators
     [:has_key]
   end
-  
+
 end

--- a/test/set_test.rb
+++ b/test/set_test.rb
@@ -1,9 +1,9 @@
 require 'test_helper'
 
 class SetTest < ActiveSupport::TestCase
-  
-  
-  
+
+
+
   test "set data struture" do
     data = [
       [:awesome],
@@ -32,7 +32,7 @@ class SetTest < ActiveSupport::TestCase
     set = Friend.that_belong_to(data)
     refute set.valid?
   end
-  
+
   test "sets lacking expected modifiers should be invalid" do
     data = [[:born, {:ever => []}]]
     set = Friend.that_belong_to(data)
@@ -41,8 +41,8 @@ class SetTest < ActiveSupport::TestCase
     data = [[:born]]
     set = Friend.that_belong_to(data)
     assert_equal false, set.valid?
-  end  
-  
+  end
+
   test "set structure with negations (nouns are ignored)" do
     data = [
       ["!awesome"],
@@ -53,7 +53,7 @@ class SetTest < ActiveSupport::TestCase
     assert set.valid?
     assert_equal "who are not awesome, who have not attended McKendree, who have not died, and whose name is Jerome", set.to_s
   end
-  
+
   test "simple perform" do
     data = [[:awesome]]
     set = Friend.that_belong_to(data)
@@ -61,7 +61,7 @@ class SetTest < ActiveSupport::TestCase
     expected_results = [{:conditions => {:awesome => true}}]
     assert_equal expected_results, set.perform
   end
-  
+
   test "complex perform" do
     data = [
       [:awesome],
@@ -69,7 +69,7 @@ class SetTest < ActiveSupport::TestCase
       [:died],
       [:name, {:begins_with => "Jerome"}]]
     set = Friend.that_belong_to(data)
-    
+
     expected_results = [
       {:conditions => {:awesome => true}},
       {:joins => "INNER JOIN schools ON friends.school_id=schools.id", :conditions => {"schools.id" => 1}},
@@ -78,7 +78,7 @@ class SetTest < ActiveSupport::TestCase
     ]
     assert_equal expected_results, set.perform
   end
-  
+
   test "invalid set" do
     data = [[:name, {:starts_with => "Jerome"}]]  # starts_with is not a valid operator
     set = Friend.that_belong_to(data)

--- a/test/set_test.rb
+++ b/test/set_test.rb
@@ -5,70 +5,61 @@ class SetTest < ActiveSupport::TestCase
 
 
   test "set data struture" do
-    data = [
+    set = to_set [
       [:awesome],
       [:attended, 2],
       [:died],
       [:name, {:is => "Jerome"}]]
-    set = Friend.that_belong_to(data)
     assert set.valid?
     assert_equal "who are awesome, who have attended McKendree, who died, and whose name is Jerome", set.to_s
   end
 
   test "sets with invalid modifiers should be invalid" do
-    data = [[:born, {:after => ["wrong"]}]]
-    set = Friend.that_belong_to(data)
+    set = to_set [[:born, {:after => ["wrong"]}]]
     assert_equal false, set.valid?
   end
 
   test "sets should not allow non-numbers in a number modifiers" do
-    data = [[:age, {:is => ["12a"]}]]
-    set = Friend.that_belong_to(data)
+    set = to_set [[:age, {:is => ["12a"]}]]
     refute set.valid?
   end
 
   test "sets should not allow empty string in a number modifiers" do
-    data = [[:age, {:is => [""]}]]
-    set = Friend.that_belong_to(data)
+    set = to_set [[:age, {:is => [""]}]]
     refute set.valid?
   end
 
   test "sets lacking expected modifiers should be invalid" do
-    data = [[:born, {:ever => []}]]
-    set = Friend.that_belong_to(data)
+    set = to_set [[:born, {:ever => []}]]
     assert_equal true, set.valid?
-    
-    data = [[:born]]
-    set = Friend.that_belong_to(data)
+
+    set = to_set [[:born]]
     assert_equal false, set.valid?
   end
 
   test "set structure with negations (nouns are ignored)" do
-    data = [
+    set = to_set [
       ["!awesome"],
       ["!attended", 2],
       ["!died"],
       ["!name", {:is => "Jerome"}]]
-    set = Friend.that_belong_to(data)
     assert set.valid?
     assert_equal "who are not awesome, who have not attended McKendree, who have not died, and whose name is Jerome", set.to_s
   end
 
   test "simple perform" do
-    data = [[:awesome]]
-    set = Friend.that_belong_to(data)
-    
+    set = to_set [[:awesome]]
+
     expected_results = [{:conditions => {:awesome => true}}]
     assert_equal expected_results, set.perform
   end
 
   test "complex perform" do
-    data = [
+    set = to_set [
       [:awesome],
       [:attended, 1],
       [:died],
       [:name, {:begins_with => "Jerome"}]]
-    set = Friend.that_belong_to(data)
 
     expected_results = [
       {:conditions => {:awesome => true}},
@@ -80,12 +71,17 @@ class SetTest < ActiveSupport::TestCase
   end
 
   test "invalid set" do
-    data = [[:name, {:starts_with => "Jerome"}]]  # starts_with is not a valid operator
-    set = Friend.that_belong_to(data)
-    
+    set = to_set [[:name, {:starts_with => "Jerome"}]]  # starts_with is not a valid operator
+
     # !todo: what to do?
     skip "TODO: test invalid sets"
   end
 
+
+private
+
+  def to_set(data)
+    SetBuilder::Set.new($friend_traits, Friend.all, data)
+  end
 
 end

--- a/test/set_test.rb
+++ b/test/set_test.rb
@@ -84,6 +84,7 @@ class SetTest < ActiveSupport::TestCase
     set = Friend.that_belong_to(data)
     
     # !todo: what to do?
+    skip "TODO: test invalid sets"
   end
 
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,7 +6,8 @@ require "set_builder"
 require "pry"
 require "support/fake_connection"
 
-
+require "minitest/reporters"
+Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new
 
 # Sample class used by tests
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -47,23 +47,20 @@ class Friend
   def self.to_scope
     []
   end
-  
-  
-  
+
+
   # Stubs so that Arel can SQL
-  
+
   attr_accessor :connection_pool
-  
+
   def initialize
     @connection_pool = Fake::ConnectionPool.new
   end
-  
+
   def connection
     connection_pool.connection
   end
-  
-  
-  
+
 end
 
 Arel::Table.engine = Arel::Sql::Engine.new(Friend.new)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,8 +13,7 @@ Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new
 
 SetBuilder::ValueMap.register(:school, [[1, "Concordia"], [2, "McKendree"]])
 
-class Friend
-  extend SetBuilder
+$friend_traits = SetBuilder::Traits.new do
 
   trait('who are [not] "awesome"') do |query, scope|
     scope << {:conditions => {:awesome => true}}
@@ -42,9 +41,13 @@ class Friend
   trait('whose "name" <string>') do |query, scope|
     scope << {:conditions => query.modifiers[0].build_conditions_for("friends.name")}
   end
-  
-  # by stubbing out scoped, we can unit test the `performed` features
-  def self.to_scope
+end
+
+
+class Friend
+
+  # by stubbing out `all`, we can unit test `Set#perform`
+  def self.all
     []
   end
 

--- a/test/trait_test.rb
+++ b/test/trait_test.rb
@@ -5,7 +5,7 @@ class TraitTest < ActiveSupport::TestCase
 
 
   test "constraints find correct modifiers" do
-    trait = Friend.traits[:name]
+    trait = $friend_traits[:name]
     assert_equal 1, trait.modifiers.length
 
     constraint = trait.apply({:is => "Jerome"})
@@ -14,7 +14,7 @@ class TraitTest < ActiveSupport::TestCase
   end
 
   test "modifiers should find correct values" do
-    trait = Friend.traits[:name]
+    trait = $friend_traits[:name]
     modifier = trait.apply({:is => "Jerome"}).modifiers.first
     assert_equal :is, modifier.operator
     assert_equal ["Jerome"], modifier.values
@@ -29,12 +29,12 @@ class TraitTest < ActiveSupport::TestCase
       :name => false
     }
     trait_requires_direct_object.each do |trait, expected_value|
-      assert_equal expected_value, Friend.traits[trait].requires_direct_object?
+      assert_equal expected_value, $friend_traits[trait].requires_direct_object?
     end
   end
 
   test "constraint should be valid" do
-    trait = Friend.traits[:name]
+    trait = $friend_traits[:name]
     constraint = trait.apply({:is => "Jerome"})
     assert constraint.valid?
   end

--- a/test/trait_test.rb
+++ b/test/trait_test.rb
@@ -12,7 +12,7 @@ class TraitTest < ActiveSupport::TestCase
     assert_equal 1, constraint.modifiers.length
     assert_kind_of StringPreposition, constraint.modifiers.first
   end
-  
+
   test "modifiers should find correct values" do
     trait = Friend.traits[:name]
     modifier = trait.apply({:is => "Jerome"}).modifiers.first

--- a/test/trait_test.rb
+++ b/test/trait_test.rb
@@ -33,12 +33,6 @@ class TraitTest < ActiveSupport::TestCase
     end
   end
 
-  # test "traits whose direct objects support value mapping should be able to enumerate their values" do
-  #   trait = Friend.traits[:attended]
-  #   expected_map = {1 => "Concordia", 2 => "McKendree"}
-  #   actual_map = trait.
-  # end
-  
   test "constraint should be valid" do
     trait = Friend.traits[:name]
     constraint = trait.apply({:is => "Jerome"})

--- a/test/traits_test.rb
+++ b/test/traits_test.rb
@@ -6,11 +6,11 @@ class TraitsTest < ActiveSupport::TestCase
 
   test "traits" do
     expected_traits = %w{age attended awesome born died name}
-    assert_equal expected_traits, Friend.traits.collect(&:name).sort
+    assert_equal expected_traits, $friend_traits.collect(&:name).sort
   end
 
   test "traits' accessor" do
-    traits = Friend.traits
+    traits = $friend_traits
     assert_kind_of SetBuilder::Traits, traits
     assert_equal "awesome", traits[0].name, "Array getter should still work like normal"
     assert_kind_of SetBuilder::Trait, traits[:born], "If you pass a string or symbol Traits should lookup a trait by name"
@@ -24,7 +24,7 @@ class TraitsTest < ActiveSupport::TestCase
 
   test "collection of modifiers" do
     expected_modifiers = %w{DatePreposition NumberPreposition StringPreposition}.collect {|name| "SetBuilder::Modifiers::#{name}"}
-    assert_equal expected_modifiers, Friend.traits.modifiers.collect(&:name).sort
+    assert_equal expected_modifiers, $friend_traits.modifiers.collect(&:name).sort
   end
 
   test "to_json" do
@@ -47,7 +47,7 @@ class TraitsTest < ActiveSupport::TestCase
      [["string","whose"],
       ["name","name"],
       ["modifier","string"]]].to_json
-    assert_equal expected_json, Friend.traits.to_json
+    assert_equal expected_json, $friend_traits.to_json
   end
 
 

--- a/test/traits_test.rb
+++ b/test/traits_test.rb
@@ -8,25 +8,25 @@ class TraitsTest < ActiveSupport::TestCase
     expected_traits = %w{age attended awesome born died name}
     assert_equal expected_traits, Friend.traits.collect(&:name).sort
   end
-  
+
   test "traits' accessor" do
     traits = Friend.traits
     assert_kind_of SetBuilder::Traits, traits
     assert_equal "awesome", traits[0].name, "Array getter should still work like normal"
     assert_kind_of SetBuilder::Trait, traits[:born], "If you pass a string or symbol Traits should lookup a trait by name"
   end
-  
+
   test "trait method is protected" do
     assert_raises NoMethodError, "this method is for use within class definition" do
       Friend.trait
     end
   end
-  
+
   test "collection of modifiers" do
     expected_modifiers = %w{DatePreposition NumberPreposition StringPreposition}.collect {|name| "SetBuilder::Modifiers::#{name}"}
     assert_equal expected_modifiers, Friend.traits.modifiers.collect(&:name).sort
   end
-  
+
   test "to_json" do
     expected_json = [[["string","who are"],
       ["negative","not"],

--- a/test/traits_test.rb
+++ b/test/traits_test.rb
@@ -27,6 +27,34 @@ class TraitsTest < ActiveSupport::TestCase
     assert_equal expected_modifiers, $friend_traits.modifiers.collect(&:name).sort
   end
 
+  test "two collections of traits can be concatenated with `+`" do
+    traits1 = SetBuilder::Traits.new do
+      trait('who are [not] "awesome"') { |query, scope| }
+    end
+
+    traits2 = SetBuilder::Traits.new do
+      trait('who are [not] "living"') { |query, scope| }
+    end
+
+    combined_traits = traits1 + traits2
+    assert_kind_of SetBuilder::Traits, combined_traits
+    assert_equal %w{awesome living}, combined_traits.map(&:name)
+  end
+
+  test "two collections of traits can be concatenated with `concat`" do
+    traits1 = SetBuilder::Traits.new do
+      trait('who are [not] "awesome"') { |query, scope| }
+    end
+
+    traits2 = SetBuilder::Traits.new do
+      trait('who are [not] "living"') { |query, scope| }
+    end
+
+    combined_traits = traits1.concat traits2
+    assert_kind_of SetBuilder::Traits, combined_traits
+    assert_equal %w{awesome living}, combined_traits.map(&:name)
+  end
+
   test "to_json" do
     expected_json = [[["string","who are"],
       ["negative","not"],

--- a/test/value_map_test.rb
+++ b/test/value_map_test.rb
@@ -7,20 +7,20 @@ class ValueMapTest < ActiveSupport::TestCase
     expected_map = [[1, "Concordia"], [2, "McKendree"]]
     assert_equal expected_map, SetBuilder::ValueMap.for(:school)
   end
-  
-  
-  test "value map should fetch the correct value" do 
+
+
+  test "value map should fetch the correct value" do
     expected_school = "Concordia"
     assert_equal expected_school, SetBuilder::ValueMap.to_s(:school, 1)
   end
 
 
-  test "value map should fetch the correct value when passed as a string" do 
+  test "value map should fetch the correct value when passed as a string" do
     expected_school = "Concordia"
     assert_equal expected_school, SetBuilder::ValueMap.to_s("school", 1)
   end
-  
-  
+
+
   test "value map should generate json that can be handed to the client-side SetBuilder" do
     expected_json = "{\"school\":[[1,\"Concordia\"],[2,\"McKendree\"]]}"
     assert_equal expected_json, SetBuilder::ValueMap.to_json


### PR DESCRIPTION
Before, SetBuilder provided a DSL for declaring traits on a model and then required you to pass that model to a Set.

This forced the client to store collections of traits in instance variables on classes — i.e. as globals.

In order to allow clients to store trait collections in local variables and pass them in to sets (to avoid all the pitfalls of global variables), we've refactored the DSL so that you contsruct Trait Collections independently of models and pass them into sets.