### PR TITLE
DatePreposition is generating the wrong SQL to find NULL values

### DIFF
--- a/test/date_preposition_test.rb
+++ b/test/date_preposition_test.rb
@@ -19,5 +19,14 @@ class DatePrepositionTest < ActiveSupport::TestCase
     end
   end
 
+  test "should use 'IS NOT NULL' rather than '!= NULL'" do
+    modifier = DatePreposition.new(operator: :ever, values: [])
+    assert_equal "\"people\".\"birthday\" IS NOT NULL",
+      modifier.build_arel_for(table[:birthday]).to_sql
+
+    assert_equal "values.value::date IS NOT NULL",
+      modifier.build_arel_for(Arel.sql("values.value::date")).to_sql
+  end
+
 
 end


### PR DESCRIPTION
I think this is a bug in Arel:

```ruby
people[:birthday].not_eq(nil) # => "people.birthday IS NOT NULL"
Arel.sql("values.value::date").not_eq(nil) # => "values.value != NULL"
```

The latter is invalid syntax.

This PR has a failing test, but not a fix.