### PR TITLE
Added ability to express operator arguments string-style

### DIFF
--- a/lib/assets/javascripts/set_builder.js
+++ b/lib/assets/javascripts/set_builder.js
@@ -247,7 +247,7 @@ SetBuilder.Modifiers = function(_modifiers) {
     var operator = args.operator;
     if(!operator) throw 'An operator name was not supplied.'
 
-    var params = this.params_for_operator(modifier_type, operator);
+    var params = this.params_for_operator(modifier_type, operator).__select(function(token) { return token[0] == 'arg' });
     var values = args.values;
 
     if(!values) values = [];

--- a/lib/assets/javascripts/set_builder.js
+++ b/lib/assets/javascripts/set_builder.js
@@ -174,11 +174,16 @@ SetBuilder.Modifier = function(_name, _operator, _values, _params) {
   }
 
   this.toString = function() {
-    var words = [_operator.replace(/_/, ' ')];
-    for(var i=0; i<_values.length; i++) {
-      words.push(SetBuilder.getValue(_params[i], _values[i]));
+    var words = [_operator.replace(/_/, ' '), ' '];
+    var __values = _values.dup();
+    for(var i=0; i<_params.length; i++) {
+      if(_params[i][0] == 'arg') {
+        words.push(SetBuilder.getValue(_params[i][1], __values.shift()));
+      } else {
+        words.push(_params[i][1])
+      }
     }
-    return words.join(' ');
+    return words.join('');
   }
 
 };
@@ -247,13 +252,14 @@ SetBuilder.Modifiers = function(_modifiers) {
     var operator = args.operator;
     if(!operator) throw 'An operator name was not supplied.'
 
-    var params = this.params_for_operator(modifier_type, operator).__select(function(token) { return token[0] == 'arg' });
+    var params = this.params_for_operator(modifier_type, operator)
+    var paramsLength = params.__select(function(token) { return token[0] == 'arg' }).length;
     var values = args.values;
 
     if(!values) values = [];
     if(!(values instanceof Array)) values = [values];
-    if(values.length != params.length) {
-      throw ('The operator "' + operator.toString() + '" expects ' + params.length + ' arguments but received ' + values.length + '.');
+    if(values.length != paramsLength) {
+      throw ('The operator "' + operator.toString() + '" expects ' + paramsLength + ' arguments but received ' + values.length + '.');
     }
 
     return new SetBuilder.Modifier(name, operator, values, params);

--- a/lib/set_builder/modifier/arguments.rb
+++ b/lib/set_builder/modifier/arguments.rb
@@ -1,13 +1,15 @@
-require "pry"
+require "set_builder/parser"
 
 module SetBuilder
   module Modifier
     class Arguments
       attr_reader :arguments, :expression, :tokens
 
+      include Parser
+
       def initialize(expression)
         @expression = expression.respond_to?(:each) ? map_legacy_arguments(expression) : expression
-        @tokens = parse
+        @tokens = parse(@expression)
       end
 
       def arity
@@ -42,33 +44,6 @@ module SetBuilder
         puts "DEPRECATED: SetBuilder::Modifier should use expression style argumenents now e.g.-> \"#{_expression}\""
         _expression
       end
-
-      def parse
-        tokenizer = Regexp.union(LEXER.values)
-        expression.split(tokenizer).each_with_object([]) do |lexeme, output|
-          next if lexeme.empty?
-          token = token_for(lexeme)
-          output.push [token, value_for(token, lexeme)]
-        end
-      end
-
-      def token_for(lexeme)
-        LEXER.each { |token, pattern| return token if pattern.match(lexeme) }
-        :string
-      end
-
-      def value_for(token, lexeme)
-        case token
-        when :arg then lexeme[1...-1]
-        when :enum then lexeme[1...-1].split("|")
-        else lexeme
-        end
-      end
-
-      LEXER = {
-        arg:  /(\{[^\}]+\})/,
-        enum: /(\[[^\]]+\])/
-      }.freeze
 
     end
   end

--- a/lib/set_builder/modifier/arguments.rb
+++ b/lib/set_builder/modifier/arguments.rb
@@ -13,10 +13,10 @@ module SetBuilder
       end
 
       def arity
-        list.count
+        types.count
       end
 
-      def list
+      def types
         @types ||= @tokens
           .select { |token, _| token == :arg }
           .map { |_, type| type }

--- a/lib/set_builder/modifier/arguments.rb
+++ b/lib/set_builder/modifier/arguments.rb
@@ -1,0 +1,75 @@
+require "pry"
+
+module SetBuilder
+  module Modifier
+    class Arguments
+      attr_reader :arguments, :expression, :tokens
+
+      def initialize(expression)
+        @expression = expression.respond_to?(:each) ? map_legacy_arguments(expression) : expression
+        @tokens = parse
+      end
+
+      def arity
+        list.count
+      end
+
+      def list
+        @types ||= @tokens
+          .select { |token, _| token == :arg }
+          .map { |_, type| type }
+      end
+
+      def as_json(*)
+        tokens.map { |(token, value)| [token.to_s, value] }
+      end
+
+      def to_s(values)
+        _values = values.dup
+        tokens.map do |token, token_value|
+          if token == :arg
+            ValueMap.to_s(token_value, _values.shift)
+          else
+            token_value
+          end
+        end.join
+      end
+
+    private
+
+      def map_legacy_arguments(arguments)
+        _expression = arguments.map { |arg| "{#{arg}}" }.join(" ")
+        puts "DEPRECATED: SetBuilder::Modifier should use expression style argumenents now e.g.-> \"#{_expression}\""
+        _expression
+      end
+
+      def parse
+        tokenizer = Regexp.union(LEXER.values)
+        expression.split(tokenizer).each_with_object([]) do |lexeme, output|
+          next if lexeme.empty?
+          token = token_for(lexeme)
+          output.push [token, value_for(token, lexeme)]
+        end
+      end
+
+      def token_for(lexeme)
+        LEXER.each { |token, pattern| return token if pattern.match(lexeme) }
+        :string
+      end
+
+      def value_for(token, lexeme)
+        case token
+        when :arg then lexeme[1...-1]
+        when :enum then lexeme[1...-1].split("|")
+        else lexeme
+        end
+      end
+
+      LEXER = {
+        arg:  /(\{[^\}]+\})/,
+        enum: /(\[[^\]]+\])/
+      }.freeze
+
+    end
+  end
+end

--- a/lib/set_builder/modifier/base.rb
+++ b/lib/set_builder/modifier/base.rb
@@ -80,7 +80,7 @@ module SetBuilder
 
 
 
-      def to_s(negative=false)
+      def to_s
         arguments = self.class.parsed_operators[operator] || Arguments.new("")
         operator.to_s.gsub(/_/, " ") + " " + arguments.to_s(values)
       end
@@ -88,13 +88,8 @@ module SetBuilder
 
 
       def self.parsed_operators
-        @parsed_operators ||= begin
-          Hash[
-            operators.map do |operator, arguments|
-              [operator, Arguments.new(arguments)]
-            end
-          ]
-        end
+        @parsed_operators ||= Hash[operators.map { |operator, arguments|
+          [operator, Arguments.new(arguments)] }]
       end
 
 
@@ -106,11 +101,8 @@ module SetBuilder
 
 
       def self.to_hash
-        Hash[
-          parsed_operators.map do |operator, arguments|
-            [operator.to_s, arguments.as_json]
-          end
-        ]
+        Hash[parsed_operators.map { |operator, arguments|
+            [operator.to_s, arguments.as_json] }]
       end
 
 

--- a/lib/set_builder/modifier/base.rb
+++ b/lib/set_builder/modifier/base.rb
@@ -1,3 +1,5 @@
+require "set_builder/modifier/arguments"
+
 module SetBuilder
   module Modifier
     class Base
@@ -43,11 +45,11 @@ module SetBuilder
 
       def errors_with_values
         [].tap do |errors|
-          types = self.class.operators[operator] || []
-          if values.length != types.length
-            errors.push "wrong number of arguments; expected #{types.length} (#{types.join(", ")})"
+          arguments = self.class.parsed_operators[operator] || Arguments.new("")
+          if values.length != arguments.arity
+            errors.push "wrong number of arguments; expected #{arguments.arity} (#{arguments.list.join(", ")})"
           else
-            errors.concat values.each_with_index.flat_map { |value, i| errors_with_value_type(value, types[i]) }
+            errors.concat values.each_with_index.flat_map { |value, i| errors_with_value_type(value, arguments.list[i]) }
           end
         end
       end
@@ -79,12 +81,20 @@ module SetBuilder
 
 
       def to_s(negative=false)
-        words = negative ? [self.class.negate(operator).to_s.gsub(/_/, " ")] : [operator.to_s.gsub(/_/, " ")]
-        arguments = self.class.operators[operator] || []
-        (0...arguments.length).each do |i|
-          words << ValueMap.to_s(arguments[i], values[i])
+        arguments = self.class.parsed_operators[operator] || Arguments.new("")
+        operator.to_s.gsub(/_/, " ") + " " + arguments.to_s(values)
+      end
+
+
+
+      def self.parsed_operators
+        @parsed_operators ||= begin
+          Hash[
+            operators.map do |operator, arguments|
+              [operator, Arguments.new(arguments)]
+            end
+          ]
         end
-        words.join(" ")
       end
 
 
@@ -96,11 +106,11 @@ module SetBuilder
 
 
       def self.to_hash
-        hash = {}
-        operators.each do |operator, array|
-          hash[operator.to_s] = array.map {|type| type.to_s }
-        end
-        hash
+        Hash[
+          parsed_operators.map do |operator, arguments|
+            [operator.to_s, arguments.as_json]
+          end
+        ]
       end
 
 

--- a/lib/set_builder/modifier/base.rb
+++ b/lib/set_builder/modifier/base.rb
@@ -47,9 +47,9 @@ module SetBuilder
         [].tap do |errors|
           arguments = self.class.parsed_operators[operator] || Arguments.new("")
           if values.length != arguments.arity
-            errors.push "wrong number of arguments; expected #{arguments.arity} (#{arguments.list.join(", ")})"
+            errors.push "wrong number of arguments; expected #{arguments.arity} (#{arguments.types.join(", ")})"
           else
-            errors.concat values.each_with_index.flat_map { |value, i| errors_with_value_type(value, arguments.list[i]) }
+            errors.concat values.each_with_index.flat_map { |value, i| errors_with_value_type(value, arguments.types[i]) }
           end
         end
       end

--- a/lib/set_builder/modifiers/date_preposition.rb
+++ b/lib/set_builder/modifiers/date_preposition.rb
@@ -7,14 +7,14 @@ module SetBuilder
 
       def self.operators
         {
-          :ever => [],
-          :before => [:date],
-          :after => [:date],
-          :on => [:date],
-          :during_month => [:month],
-          :during_year => [:year],
-          :in_the_last => [:number, :period],
-          :between => [:date, :date]
+          :ever => "",
+          :before => "{date}",
+          :after => "{date}",
+          :on => "{date}",
+          :during_month => "{month}",
+          :during_year => "{year}",
+          :in_the_last => "{number} {period}",
+          :between => "{date} and {date}"
         }
       end
 

--- a/lib/set_builder/modifiers/number_preposition.rb
+++ b/lib/set_builder/modifiers/number_preposition.rb
@@ -7,10 +7,10 @@ module SetBuilder
 
       def self.operators
         {
-          :is => [:number],
-          :is_less_than => [:number],
-          :is_greater_than => [:number],
-          :is_between => [:number, :number]
+          :is => "{number}",
+          :is_less_than => "{number}",
+          :is_greater_than => "{number}",
+          :is_between => "{number} and {number}"
         }
       end
 

--- a/lib/set_builder/modifiers/string_preposition.rb
+++ b/lib/set_builder/modifiers/string_preposition.rb
@@ -7,14 +7,14 @@ module SetBuilder
 
       def self.operators
         {
-          :contains => [:string],
-          :does_not_contain => [:string],
-          :begins_with => [:string],
-          :does_not_begin_with => [:string],
-          :ends_with => [:string],
-          :does_not_end_with => [:string],
-          :is => [:string],
-          :is_not => [:string]
+          :contains => "{string}",
+          :does_not_contain => "{string}",
+          :begins_with => "{string}",
+          :does_not_begin_with => "{string}",
+          :ends_with => "{string}",
+          :does_not_end_with => "{string}",
+          :is => "{string}",
+          :is_not => "{string}"
         }
       end
 

--- a/lib/set_builder/parser.rb
+++ b/lib/set_builder/parser.rb
@@ -1,0 +1,36 @@
+module SetBuilder
+  module Parser
+
+    def parse(expression)
+      tokenizer = Regexp.union(LEXER.values)
+      expression.split(tokenizer).each_with_object([]) do |lexeme, output|
+        next if lexeme.empty?
+        token = token_for(lexeme)
+        output.push [token, value_for(token, lexeme)]
+      end
+    end
+
+    def token_for(lexeme)
+      LEXER.each { |token, pattern| return token if pattern.match(lexeme) }
+      :string
+    end
+
+    def value_for(token, lexeme)
+      case token
+      when :name, :modifier, :arg then lexeme[1...-1]
+      when :enum then lexeme[1...-1].split("|")
+      when :direct_object_type then lexeme[1..-1]
+      else lexeme
+      end
+    end
+
+    LEXER = {
+      name: /("[^"]+")/,
+      direct_object_type: /(:[\w\-\.]+)/,
+      enum: /(\[[^\]]+\])/,
+      modifier: /(<\w+>)/,
+      arg:  /(\{[^\}]+\})/
+    }.freeze
+
+  end
+end

--- a/lib/set_builder/trait.rb
+++ b/lib/set_builder/trait.rb
@@ -1,11 +1,13 @@
 require "set_builder/constraint"
 require "set_builder/modifier"
+require "set_builder/parser"
 
 
 module SetBuilder
   class Trait
     attr_reader :expression, :tokens, :name, :modifiers, :direct_object_type, :enums
 
+    include Parser
 
 
     def initialize(expression, &block)
@@ -62,39 +64,6 @@ module SetBuilder
     def find(token)
       find_all(token).first
     end
-
-
-
-    def parse(expression)
-      tokenizer = Regexp.union(LEXER.values)
-      expression.split(tokenizer).each_with_object([]) do |lexeme, output|
-        next if lexeme.empty?
-        token = token_for(lexeme)
-        output.push [token, value_for(token, lexeme)]
-      end
-    end
-
-    def token_for(lexeme)
-      LEXER.each { |token, pattern| return token if pattern.match(lexeme) }
-      :string
-    end
-
-    def value_for(token, lexeme)
-      case token
-      when :name then lexeme[1...-1]
-      when :enum then lexeme[1...-1].split("|")
-      when :modifier then lexeme[1...-1]
-      when :direct_object_type then lexeme[1..-1]
-      else lexeme
-      end
-    end
-
-    LEXER = {
-      name: /("[^"]+")/,
-      direct_object_type: /(:[\w\-\.]+)/,
-      enum: /(\[[^\]]+\])/,
-      modifier: /(<\w+>)/
-    }.freeze
 
 
 

--- a/spec/unit/set_builder.spec.js
+++ b/spec/unit/set_builder.spec.js
@@ -36,6 +36,9 @@ describe 'SetBuilder'
         begins_with: [['arg', 'string']],
         ends_with: [['arg', 'string']],
         is: [['arg', 'string']]
+      },
+      date: {
+        between: [['arg', 'date'], ['string', ' and '], ['arg', 'date']]
       }
     });
 
@@ -153,7 +156,7 @@ describe 'SetBuilder'
 
     describe '.length'
       it 'should have parsed the data structure correctly'
-        expect(modifiers.length()).to(be, 1);
+      expect(modifiers.length()).to(be, 2);
       end
     end
 
@@ -207,6 +210,14 @@ describe 'SetBuilder'
           { trait: 'name', modifiers: [{ operator: 'is', values: ['Jerome'] }] }
         ]);
         var expected_string = 'who are not awesome, who have not attended Concordia, who have not died, and whose name is Jerome'
+        expect(set.toString()).to(eql, expected_string);
+      end
+
+      it 'should generate the natural language description of a set with extra text in modifier arguments'
+        var set = new SetBuilder.Set([
+          { trait: 'born', modifiers: [{ operator: 'between', values: ['Jan 1, 2016', 'Jan 2, 2016'] }]}
+        ])
+        var expected_string = 'who were born between Jan 1, 2016 and Jan 2, 2016';
         expect(set.toString()).to(eql, expected_string);
       end
     end

--- a/spec/unit/set_builder.spec.js
+++ b/spec/unit/set_builder.spec.js
@@ -32,10 +32,10 @@ describe 'SetBuilder'
 
     SetBuilder.registerModifiers({
       string: {
-        contains: ['string'],
-        begins_with: ['string'],
-        ends_with: ['string'],
-        is: ['string']
+        contains: [['arg', 'string']],
+        begins_with: [['arg', 'string']],
+        ends_with: [['arg', 'string']],
+        is: [['arg', 'string']]
       }
     });
 

--- a/test/modifier_test.rb
+++ b/test/modifier_test.rb
@@ -55,14 +55,14 @@ class ModifierTest < ActiveSupport::TestCase
 
   test "converting modifier to json" do
     expected_results = {
-      "contains"            => ["string"],
-      "does_not_contain"    => ["string"],
-      "begins_with"         => ["string"],
-      "does_not_begin_with" => ["string"],
-      "ends_with"           => ["string"],
-      "does_not_end_with"   => ["string"],
-      "is"                  => ["string"],
-      "is_not"              => ["string"]
+      "contains"            => [["arg", "string"]],
+      "does_not_contain"    => [["arg", "string"]],
+      "begins_with"         => [["arg", "string"]],
+      "does_not_begin_with" => [["arg", "string"]],
+      "ends_with"           => [["arg", "string"]],
+      "does_not_end_with"   => [["arg", "string"]],
+      "is"                  => [["arg", "string"]],
+      "is_not"              => [["arg", "string"]]
     }.to_json
     assert_equal expected_results, SetBuilder::Modifier.for(:string).to_json
   end
@@ -71,29 +71,29 @@ class ModifierTest < ActiveSupport::TestCase
     expected_results = {
       "date" => {
         "ever"        => [],
-        "after"       => ["date"],
-        "before"      => ["date"],
-        "on"          => ["date"],
-        "in_the_last" => ["number", "period"],
-        "during_month"=> ["month"],
-        "during_year" => ["year"],
-        "between"     => ["date", "date"]
+        "before"      => [["arg", "date"]],
+        "after"       => [["arg", "date"]],
+        "on"          => [["arg", "date"]],
+        "during_month"=> [["arg", "month"]],
+        "during_year" => [["arg", "year"]],
+        "in_the_last" => [["arg", "number"], ["string", " "], ["arg", "period"]],
+        "between"     => [["arg", "date"], ["string", " and "], ["arg", "date"]]
       },
-      "number"=> {
-        "is"=>["number"],
-        "is_less_than"=>["number"],
-        "is_greater_than"=>["number"],
-        "is_between"=>["number", "number"]
+      "number" => {
+        "is"=>[["arg", "number"]],
+        "is_less_than"=>[["arg", "number"]],
+        "is_greater_than"=>[["arg", "number"]],
+        "is_between"=>[["arg", "number"], ["string", " and "], ["arg", "number"]]
       },
       "string" => {
-        "contains"            => ["string"],
-        "does_not_contain"    => ["string"],
-        "begins_with"         => ["string"],
-        "does_not_begin_with" => ["string"],
-        "ends_with"           => ["string"],
-        "does_not_end_with"   => ["string"],
-        "is"                  => ["string"],
-        "is_not"              => ["string"]
+        "contains"            => [["arg", "string"]],
+        "does_not_contain"    => [["arg", "string"]],
+        "begins_with"         => [["arg", "string"]],
+        "does_not_begin_with" => [["arg", "string"]],
+        "ends_with"           => [["arg", "string"]],
+        "does_not_end_with"   => [["arg", "string"]],
+        "is"                  => [["arg", "string"]],
+        "is_not"              => [["arg", "string"]]
       }
     }
     assert_equal expected_results, $friend_traits.modifiers.to_hash


### PR DESCRIPTION
Allows this:

```ruby
def self.operators
 {between: "{date} and {date}"}
end
```