### PR TITLE
Updates for rails 5 compatibility

### DIFF
--- a/set_builder.gemspec
+++ b/set_builder.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rails", "~> 4.2.0"
+  spec.add_dependency "rails", ">= 4.2.0", "< 6"
   spec.add_dependency "arel"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/test/modifier_test.rb
+++ b/test/modifier_test.rb
@@ -42,7 +42,7 @@ class ModifierTest < ActiveSupport::TestCase
       SetBuilder::Modifier.for(:hash)
     end
     SetBuilder::Modifier.register(:hash, HashModifier)
-    assert_nothing_raised ArgumentError do
+    assert_nothing_raised do
       SetBuilder::Modifier.for(:hash)
     end
   end

--- a/test/support/fake_connection.rb
+++ b/test/support/fake_connection.rb
@@ -107,5 +107,9 @@ module Fake
     def schema_cache
       connection
     end
+
+    def data_source_exists? source
+      source
+    end
   end
 end


### PR DESCRIPTION
- Unlocked the rails version dependency.
- Updated the tests. They passed on 5.0.8 and 5.2.0. There was a bug in 5.0.0 that generated errors while running the test suite.